### PR TITLE
Add JEST_REPORT_FILE_PATH config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ Also, variable supports fallback. For example:
 
 ## Output
 
-By default, the reporter writes to `test-report.json`. The file name can be changed by setting the `JEST_REPORT_FILE` environment variable.
+By default, the reporter writes to `test-report.json` under project root directory. The file name can be changed by setting the `JEST_REPORT_FILE` environment variable and the file path can be changed by setting the `JEST_REPORT_FILE_PATH` envrionment variable.
 
 ~~~sh
-JEST_REPORT_FILE="./jest-report.json" jest
+// Writes to "./__tests__/report/jest-report.json"
+JEST_REPORT_FILE="jest-report.json" JEST_REPORT_FILE_PATH="./__tests__/report" jest
 ~~~
 
 ## License

--- a/index.js
+++ b/index.js
@@ -11,9 +11,16 @@ module.exports = (results) => {
   };
 
   const filename = process.env.JEST_REPORT_FILE || "test-report.json";
+  const filePath = process.env.JEST_REPORT_FILE_PATH;
   const suiteNameTemplate =
     process.env.JEST_BAMBOO_SUITE_NAME || "{firstAncestorTitle|filePath}";
   const nameSeparator = process.env.JEST_BAMBOO_NAME_SEPARATOR || " – ";
+
+  if (filePath) {
+    if (!fs.existsSync(filePath)){
+      fs.mkdirSync(filePath);
+    }
+  }
 
   output.stats.tests = results.numTotalTests;
   output.stats.passes = results.numPassedTests;
@@ -98,6 +105,6 @@ module.exports = (results) => {
     });
   });
 
-  fs.writeFileSync(filename, JSON.stringify(output, null, 2), "utf8");
+  fs.writeFileSync(filePath? `${filePath}/${filename}` : filename, JSON.stringify(output, null, 2), "utf8");
   return results;
 };


### PR DESCRIPTION
- New env variable in JEST_REPORT_FILE_PATH
- JEST_REPORT_FILE_PATH configures the generated test report's path; if unused, the default behaviour is conserved & the test report file gets generated under the project root folder